### PR TITLE
Added resource pruning

### DIFF
--- a/addons/aseprite_spritesheet_importer/import_plugin.gd
+++ b/addons/aseprite_spritesheet_importer/import_plugin.gd
@@ -249,4 +249,13 @@ func _import(source_file: String, save_path: String, options: Dictionary, _platf
 	importer.use_import_options(options)
 	importer.use_executable(self.executable)
 	importer.use_import_plugin(self)
-	return importer.run()
+	err = importer.run()
+	for f: Resource in importer.gen_files:
+		_gen_files.append(f.resource_path)
+	
+	if importer.do_scan:
+		# EditorFileSystem.scan seems to be the only way to get the FileSystemDock to notice the
+		# textures folder is created or deleted. This often throws an error so it should be avoided
+		EditorInterface.get_resource_filesystem().scan()
+	
+	return err

--- a/addons/aseprite_spritesheet_importer/importer.gd
+++ b/addons/aseprite_spritesheet_importer/importer.gd
@@ -15,8 +15,10 @@ var import_options: Dictionary
 var aseprite_options: AsepriteExecutable.Options
 var executable: AsepriteExecutable
 var import_plugin: EditorImportPlugin
-var spritesheet_texture: Texture2D
+var spritesheet_texture: PortableCompressedTexture2D
 var spritesheet_data: Dictionary
+var gen_files: Array[Resource]
+var do_scan: bool
 
 @warning_ignore("shadowed_variable")
 func use_editor(editor: EditorInterface) -> void:
@@ -65,12 +67,14 @@ func use_import_plugin(import_plugin: EditorImportPlugin) -> void:
 	self.import_plugin = import_plugin
 
 func run() -> Error:
+	self.gen_files = []
 	var steps = [
 		self._validate,
 		self._make_fallback_texture,
 		self._export_spritesheet,
 		self._generate_atlas_textures,
 		self._generate_spriteframes,
+		self._prune_files,
 	]
 	for step in steps:
 		var err = step.call()
@@ -117,10 +121,15 @@ func _make_fallback_texture() -> Error:
 	return OK
 
 func _export_spritesheet() -> Error:
+	var editor_file_system = self.editor.get_resource_filesystem()
+	
 	# Make textures folder if required
-	if self.import_options["generate_resources/atlas_textures"] \
-	or self.import_options["generate_resources/spriteframes"]:
+	if (self.import_options["generate_resources/atlas_textures"] \
+	or self.import_options["generate_resources/spriteframes"]) \
+	and ! DirAccess.dir_exists_absolute(self.textures_folder):
 		DirAccess.make_dir_recursive_absolute(self.textures_folder)
+		# Notify import_plugin to run a scan
+		self.do_scan = true
 
 	# Execute Aseprite
 	var aseprite_result = self.executable.export_spritesheet(self.source_file, self.aseprite_options)
@@ -128,7 +137,6 @@ func _export_spritesheet() -> Error:
 		return aseprite_result[0]
 	self.spritesheet_data = aseprite_result[1]
 
-	var editor_file_system = self.editor.get_resource_filesystem()
 
 	# Delete JSON if necessary
 	if not self.import_options["debug/keep_json"]:
@@ -169,7 +177,9 @@ func _generate_atlas_textures() -> Error:
 	atlas_tools.use_texture(self.spritesheet_texture)
 	atlas_tools.use_editor(self.editor)
 	atlas_tools.split_layers = self.import_options["layers/split_layers"]
-	return atlas_tools.run()
+	var err = atlas_tools.run()
+	self.gen_files.append_array(atlas_tools.gen_files)
+	return err
 
 func _generate_spriteframes() -> Error:
 	if not self.import_options["generate_resources/spriteframes"]:
@@ -181,4 +191,48 @@ func _generate_spriteframes() -> Error:
 	spriteframe_tools.use_editor(self.editor)
 	spriteframe_tools.split_layers = self.import_options["layers/split_layers"]
 	spriteframe_tools.ignore_framerate = self.import_options["generate_resources/ignore_framerate"]
-	return spriteframe_tools.run()
+	spriteframe_tools.localize_textures = ! self.import_options["generate_resources/atlas_textures"]
+	var err = spriteframe_tools.run()
+	self.gen_files.append_array(spriteframe_tools.gen_files)
+	return err
+
+func _prune_files() -> Error:
+	
+	var prev_files: Dictionary = {}
+	var import_path = "%s.import" % self.source_file
+	var import_file = FileAccess.open(import_path, FileAccess.READ)
+	if import_file == null:
+		return FileAccess.get_open_error()
+
+	while import_file.get_position() < import_file.get_length():
+		# Find line that starts with files=
+		var line: String = import_file.get_line()
+		if line.begins_with("files="):
+			# Read previous files into a set
+			for f in JSON.parse_string(line.trim_prefix("files=")):
+				prev_files[f] = true
+	import_file.close()
+	
+	for r in self.gen_files:
+		# Remove the file from the set of previous files
+		prev_files.erase(r.resource_path)
+	
+	# Prune any previously generated files that weren't generated this time
+	var editor_file_system = editor.get_resource_filesystem()
+	for f in prev_files:
+		if FileAccess.file_exists(f):
+			var err = DirAccess.remove_absolute(f)
+			if err != OK:
+				return err
+			editor_file_system.update_file(f)
+	
+	# Delete the folder if it's empty
+	if DirAccess.dir_exists_absolute(self.textures_folder) \
+	and DirAccess.get_files_at(self.textures_folder).size() == 0:
+		var err = DirAccess.remove_absolute(self.textures_folder)
+		if err != OK:
+			return err
+		# Notify import_plugin to run a scan
+		self.do_scan = true
+
+	return OK

--- a/addons/aseprite_spritesheet_importer/util/atlas_tools.gd
+++ b/addons/aseprite_spritesheet_importer/util/atlas_tools.gd
@@ -8,6 +8,7 @@ var textures_folder: String
 var texture: Texture2D
 var split_layers: bool
 var editor: EditorInterface
+var gen_files: Array[Resource]
 
 var _frame_regions: Array[Dictionary]
 var _slice_regions: Array[Dictionary]
@@ -33,6 +34,7 @@ func use_editor(editor: EditorInterface) -> void:
 	self.editor = editor
 
 func run() -> Error:
+	self.gen_files = []
 	var err: Error
 	_read_frames()
 	if self.spritesheet_data.meta.slices.size() > 0:
@@ -232,6 +234,7 @@ func _save_atlas_textures() -> Error:
 	for atlas_texture_name in self._named_atlas_textures:
 		var atlas_texture_path: String = "%s/%s.tres" % [self.textures_folder, atlas_texture_name]
 		var err = ResourceSaver.save(self._named_atlas_textures[atlas_texture_name], atlas_texture_path)
+		gen_files.append(self._named_atlas_textures[atlas_texture_name])
 		if err != OK:
 			print("AtlasTexture save error: %s" % error_string(err))
 			return err
@@ -272,6 +275,7 @@ func _save_atlas_styleboxes() -> Error:
 	for atlas_texture_name in self._named_atlas_styleboxes:
 		var stylebox_path: String = "%s/%s_stylebox.tres" % [self.textures_folder, atlas_texture_name]
 		var err = ResourceSaver.save(self._named_atlas_styleboxes[atlas_texture_name], stylebox_path)
+		gen_files.append(self._named_atlas_styleboxes[atlas_texture_name])
 		if err != OK:
 			print("StyleBoxTexture save error: %s" % error_string(err))
 			return err

--- a/addons/aseprite_spritesheet_importer/util/spriteframe_tools.gd
+++ b/addons/aseprite_spritesheet_importer/util/spriteframe_tools.gd
@@ -3,12 +3,14 @@ class_name AsepriteUtilSpriteFrameTools
 extends AsepriteUtilAtlasTools
 
 var ignore_framerate: bool
+var localize_textures: bool
 
 var _frame_durations: Array
 var _named_spriteframes_atlas_names: Dictionary
 var _named_spriteframes: Dictionary
 
 func run() -> Error:
+	self.gen_files = []
 	_read_frames()
 	if self.spritesheet_data.meta.slices.size() > 0:
 		_read_slices()
@@ -24,6 +26,7 @@ func run() -> Error:
 			_flatten_frame_regions()
 
 	_make_load_atlas_textures()
+	_localize_atlas_textures()
 	_make_load_spriteframes()
 	_read_frame_durations()
 	_add_animations()
@@ -99,6 +102,11 @@ func _flatten_frame_regions() -> void:
 		self._named_spriteframes_atlas_names[spriteframes_name].append(atlas_texture_name)
 		self._named_atlas_regions[atlas_texture_name] = self._frame_regions[i]["default"]
 
+func _localize_atlas_textures() -> void:
+	if self.localize_textures:
+		for name: String in self._named_atlas_textures:
+			self._named_atlas_textures[name] = self._named_atlas_textures[name].duplicate(false)
+
 func _make_load_spriteframes() -> void:
 	self._named_spriteframes = {}
 	for spriteframes_name in self._named_spriteframes_atlas_names:
@@ -114,6 +122,7 @@ func _save_spriteframes() -> Error:
 	for spriteframes_name in self._named_spriteframes:
 		var sprite_frames_path: String = "%s/%s_spriteframes.tres" % [self.textures_folder, spriteframes_name]
 		var err = ResourceSaver.save(self._named_spriteframes[spriteframes_name], sprite_frames_path)
+		gen_files.append(self._named_spriteframes[spriteframes_name])
 		if err != OK:
 			print("SpriteFrames save error: %s" % error_string(err))
 			return err

--- a/examples/full/player.ase.import
+++ b/examples/full/player.ase.import
@@ -7,8 +7,10 @@ path="res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res"
 
 [deps]
 
+files=["res://examples/full/textures/player_red_guy_base_0.tres", "res://examples/full/textures/player_green_guy_base_0.tres", "res://examples/full/textures/player_red_guy_hat_0.tres", "res://examples/full/textures/player_green_guy_hat_0.tres", "res://examples/full/textures/player_red_guy_base_1.tres", "res://examples/full/textures/player_green_guy_base_1.tres", "res://examples/full/textures/player_red_guy_hat_1.tres", "res://examples/full/textures/player_green_guy_hat_1.tres", "res://examples/full/textures/player_red_guy_base_2.tres", "res://examples/full/textures/player_green_guy_base_2.tres", "res://examples/full/textures/player_red_guy_hat_2.tres", "res://examples/full/textures/player_green_guy_hat_2.tres", "res://examples/full/textures/player_red_guy_base_spriteframes.tres", "res://examples/full/textures/player_green_guy_base_spriteframes.tres", "res://examples/full/textures/player_red_guy_hat_spriteframes.tres", "res://examples/full/textures/player_green_guy_hat_spriteframes.tres"]
+
 source_file="res://examples/full/player.ase"
-dest_files=["res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res"]
+dest_files=["res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res", "res://examples/full/textures/player_red_guy_base_0.tres", "res://examples/full/textures/player_green_guy_base_0.tres", "res://examples/full/textures/player_red_guy_hat_0.tres", "res://examples/full/textures/player_green_guy_hat_0.tres", "res://examples/full/textures/player_red_guy_base_1.tres", "res://examples/full/textures/player_green_guy_base_1.tres", "res://examples/full/textures/player_red_guy_hat_1.tres", "res://examples/full/textures/player_green_guy_hat_1.tres", "res://examples/full/textures/player_red_guy_base_2.tres", "res://examples/full/textures/player_green_guy_base_2.tres", "res://examples/full/textures/player_red_guy_hat_2.tres", "res://examples/full/textures/player_green_guy_hat_2.tres", "res://examples/full/textures/player_red_guy_base_spriteframes.tres", "res://examples/full/textures/player_green_guy_base_spriteframes.tres", "res://examples/full/textures/player_red_guy_hat_spriteframes.tres", "res://examples/full/textures/player_green_guy_hat_spriteframes.tres"]
 
 [params]
 

--- a/examples/full/textures/player_green_guy_base_0.tres
+++ b/examples/full/textures/player_green_guy_base_0.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://bpqct6l72koux"]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://dhw6e2ql0h40l"]
 
 [ext_resource type="Texture2D" path="res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res" id="1_2e8hc"]
 

--- a/examples/full/textures/player_green_guy_base_1.tres
+++ b/examples/full/textures/player_green_guy_base_1.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://bu3v52gg5ra7j"]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://bqpxvepq0swx8"]
 
 [ext_resource type="Texture2D" path="res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res" id="1_k0e5f"]
 

--- a/examples/full/textures/player_green_guy_base_2.tres
+++ b/examples/full/textures/player_green_guy_base_2.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://nyl3r3hh12yt"]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://c5o80v74hs365"]
 
 [ext_resource type="Texture2D" path="res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res" id="1_4d7n7"]
 

--- a/examples/full/textures/player_green_guy_base_spriteframes.tres
+++ b/examples/full/textures/player_green_guy_base_spriteframes.tres
@@ -1,20 +1,20 @@
-[gd_resource type="SpriteFrames" load_steps=4 format=3 uid="uid://bcwg031ta8bfv"]
+[gd_resource type="SpriteFrames" load_steps=4 format=3 uid="uid://ixy62b5d74cx"]
 
-[ext_resource type="Texture2D" uid="uid://bpqct6l72koux" path="res://examples/full/textures/player_green_guy_base_0.tres" id="1_rs2u3"]
-[ext_resource type="Texture2D" uid="uid://bu3v52gg5ra7j" path="res://examples/full/textures/player_green_guy_base_1.tres" id="2_2s45o"]
-[ext_resource type="Texture2D" uid="uid://nyl3r3hh12yt" path="res://examples/full/textures/player_green_guy_base_2.tres" id="3_18afq"]
+[ext_resource type="Texture2D" uid="uid://dhw6e2ql0h40l" path="res://examples/full/textures/player_green_guy_base_0.tres" id="1_txa3o"]
+[ext_resource type="Texture2D" uid="uid://bqpxvepq0swx8" path="res://examples/full/textures/player_green_guy_base_1.tres" id="2_6pe57"]
+[ext_resource type="Texture2D" uid="uid://c5o80v74hs365" path="res://examples/full/textures/player_green_guy_base_2.tres" id="3_deoqs"]
 
 [resource]
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": ExtResource("1_rs2u3")
+"texture": ExtResource("1_txa3o")
 }, {
 "duration": 1.0,
-"texture": ExtResource("2_2s45o")
+"texture": ExtResource("2_6pe57")
 }, {
 "duration": 1.0,
-"texture": ExtResource("3_18afq")
+"texture": ExtResource("3_deoqs")
 }],
 "loop": true,
 "name": &"walk-loop",

--- a/examples/full/textures/player_green_guy_hat_0.tres
+++ b/examples/full/textures/player_green_guy_hat_0.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://bo8tj1e621lw1"]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://buaorf7sge0pv"]
 
 [ext_resource type="Texture2D" path="res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res" id="1_o3m50"]
 

--- a/examples/full/textures/player_green_guy_hat_1.tres
+++ b/examples/full/textures/player_green_guy_hat_1.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://b540bllikwgo6"]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://deo6wtkep2vxa"]
 
 [ext_resource type="Texture2D" path="res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res" id="1_04m23"]
 

--- a/examples/full/textures/player_green_guy_hat_2.tres
+++ b/examples/full/textures/player_green_guy_hat_2.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://dr47hifopkjxh"]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://clw3wrtnx307q"]
 
 [ext_resource type="Texture2D" path="res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res" id="1_ilqjr"]
 

--- a/examples/full/textures/player_green_guy_hat_spriteframes.tres
+++ b/examples/full/textures/player_green_guy_hat_spriteframes.tres
@@ -1,20 +1,20 @@
-[gd_resource type="SpriteFrames" load_steps=4 format=3 uid="uid://dmoigcyhxfmvx"]
+[gd_resource type="SpriteFrames" load_steps=4 format=3 uid="uid://cd53hf7d47rc6"]
 
-[ext_resource type="Texture2D" uid="uid://bo8tj1e621lw1" path="res://examples/full/textures/player_green_guy_hat_0.tres" id="1_u64ey"]
-[ext_resource type="Texture2D" uid="uid://b540bllikwgo6" path="res://examples/full/textures/player_green_guy_hat_1.tres" id="2_pwxkl"]
-[ext_resource type="Texture2D" uid="uid://dr47hifopkjxh" path="res://examples/full/textures/player_green_guy_hat_2.tres" id="3_nnafh"]
+[ext_resource type="Texture2D" uid="uid://buaorf7sge0pv" path="res://examples/full/textures/player_green_guy_hat_0.tres" id="1_3ba88"]
+[ext_resource type="Texture2D" uid="uid://deo6wtkep2vxa" path="res://examples/full/textures/player_green_guy_hat_1.tres" id="2_g56bu"]
+[ext_resource type="Texture2D" uid="uid://clw3wrtnx307q" path="res://examples/full/textures/player_green_guy_hat_2.tres" id="3_muqd8"]
 
 [resource]
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": ExtResource("1_u64ey")
+"texture": ExtResource("1_3ba88")
 }, {
 "duration": 1.0,
-"texture": ExtResource("2_pwxkl")
+"texture": ExtResource("2_g56bu")
 }, {
 "duration": 1.0,
-"texture": ExtResource("3_nnafh")
+"texture": ExtResource("3_muqd8")
 }],
 "loop": true,
 "name": &"walk-loop",

--- a/examples/full/textures/player_red_guy_base_0.tres
+++ b/examples/full/textures/player_red_guy_base_0.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://4rmiufdnocym"]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://dvkevqfb2usf7"]
 
 [ext_resource type="Texture2D" path="res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res" id="1_p7tdq"]
 

--- a/examples/full/textures/player_red_guy_base_1.tres
+++ b/examples/full/textures/player_red_guy_base_1.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://vw08mkkdcne5"]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://cvpr3rrvccpld"]
 
 [ext_resource type="Texture2D" path="res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res" id="1_yo5jw"]
 

--- a/examples/full/textures/player_red_guy_base_2.tres
+++ b/examples/full/textures/player_red_guy_base_2.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://bkvsobrnbcmeo"]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://cq4gm314e8o3i"]
 
 [ext_resource type="Texture2D" path="res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res" id="1_mxuo7"]
 

--- a/examples/full/textures/player_red_guy_base_spriteframes.tres
+++ b/examples/full/textures/player_red_guy_base_spriteframes.tres
@@ -1,20 +1,20 @@
-[gd_resource type="SpriteFrames" load_steps=4 format=3 uid="uid://bim1kwsi64jtn"]
+[gd_resource type="SpriteFrames" load_steps=4 format=3 uid="uid://b2raplr66ar5f"]
 
-[ext_resource type="Texture2D" uid="uid://4rmiufdnocym" path="res://examples/full/textures/player_red_guy_base_0.tres" id="1_jekct"]
-[ext_resource type="Texture2D" uid="uid://vw08mkkdcne5" path="res://examples/full/textures/player_red_guy_base_1.tres" id="2_befec"]
-[ext_resource type="Texture2D" uid="uid://bkvsobrnbcmeo" path="res://examples/full/textures/player_red_guy_base_2.tres" id="3_bv2a5"]
+[ext_resource type="Texture2D" uid="uid://dvkevqfb2usf7" path="res://examples/full/textures/player_red_guy_base_0.tres" id="1_ma1ky"]
+[ext_resource type="Texture2D" uid="uid://cvpr3rrvccpld" path="res://examples/full/textures/player_red_guy_base_1.tres" id="2_7ethe"]
+[ext_resource type="Texture2D" uid="uid://cq4gm314e8o3i" path="res://examples/full/textures/player_red_guy_base_2.tres" id="3_r6x07"]
 
 [resource]
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": ExtResource("1_jekct")
+"texture": ExtResource("1_ma1ky")
 }, {
 "duration": 1.0,
-"texture": ExtResource("2_befec")
+"texture": ExtResource("2_7ethe")
 }, {
 "duration": 1.0,
-"texture": ExtResource("3_bv2a5")
+"texture": ExtResource("3_r6x07")
 }],
 "loop": true,
 "name": &"walk-loop",

--- a/examples/full/textures/player_red_guy_hat_0.tres
+++ b/examples/full/textures/player_red_guy_hat_0.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://de7r2sx7nxdpo"]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://em0sr6y3cxuo"]
 
 [ext_resource type="Texture2D" path="res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res" id="1_tqsiy"]
 

--- a/examples/full/textures/player_red_guy_hat_1.tres
+++ b/examples/full/textures/player_red_guy_hat_1.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://1cnxox0ah7nw"]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://14ivfdbpnn8q"]
 
 [ext_resource type="Texture2D" path="res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res" id="1_65qd8"]
 

--- a/examples/full/textures/player_red_guy_hat_2.tres
+++ b/examples/full/textures/player_red_guy_hat_2.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://im5qtvyubnc7"]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://tuf3mte3b7qf"]
 
 [ext_resource type="Texture2D" path="res://.godot/imported/player.ase-a26bbc23d2870b3a344dc609403c5901.res" id="1_7xahq"]
 

--- a/examples/full/textures/player_red_guy_hat_spriteframes.tres
+++ b/examples/full/textures/player_red_guy_hat_spriteframes.tres
@@ -1,20 +1,20 @@
-[gd_resource type="SpriteFrames" load_steps=4 format=3 uid="uid://djmo1s3ewhci3"]
+[gd_resource type="SpriteFrames" load_steps=4 format=3 uid="uid://5dv6ruwexvx2"]
 
-[ext_resource type="Texture2D" uid="uid://de7r2sx7nxdpo" path="res://examples/full/textures/player_red_guy_hat_0.tres" id="1_ahmun"]
-[ext_resource type="Texture2D" uid="uid://1cnxox0ah7nw" path="res://examples/full/textures/player_red_guy_hat_1.tres" id="2_41dxx"]
-[ext_resource type="Texture2D" uid="uid://im5qtvyubnc7" path="res://examples/full/textures/player_red_guy_hat_2.tres" id="3_cy4gp"]
+[ext_resource type="Texture2D" uid="uid://em0sr6y3cxuo" path="res://examples/full/textures/player_red_guy_hat_0.tres" id="1_nbkk6"]
+[ext_resource type="Texture2D" uid="uid://14ivfdbpnn8q" path="res://examples/full/textures/player_red_guy_hat_1.tres" id="2_vymg0"]
+[ext_resource type="Texture2D" uid="uid://tuf3mte3b7qf" path="res://examples/full/textures/player_red_guy_hat_2.tres" id="3_5s0yl"]
 
 [resource]
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": ExtResource("1_ahmun")
+"texture": ExtResource("1_nbkk6")
 }, {
 "duration": 1.0,
-"texture": ExtResource("2_41dxx")
+"texture": ExtResource("2_vymg0")
 }, {
 "duration": 1.0,
-"texture": ExtResource("3_cy4gp")
+"texture": ExtResource("3_5s0yl")
 }],
 "loop": true,
 "name": &"walk-loop",

--- a/examples/no_slices/player.ase.import
+++ b/examples/no_slices/player.ase.import
@@ -7,8 +7,10 @@ path="res://.godot/imported/player.ase-649fcf8a2257b71cde62860b682ed741.res"
 
 [deps]
 
+files=["res://examples/no_slices/textures/player_0.tres", "res://examples/no_slices/textures/player_1.tres", "res://examples/no_slices/textures/player_2.tres", "res://examples/no_slices/textures/player_spriteframes.tres"]
+
 source_file="res://examples/no_slices/player.ase"
-dest_files=["res://.godot/imported/player.ase-649fcf8a2257b71cde62860b682ed741.res"]
+dest_files=["res://.godot/imported/player.ase-649fcf8a2257b71cde62860b682ed741.res", "res://examples/no_slices/textures/player_0.tres", "res://examples/no_slices/textures/player_1.tres", "res://examples/no_slices/textures/player_2.tres", "res://examples/no_slices/textures/player_spriteframes.tres"]
 
 [params]
 

--- a/examples/one_layer/player.ase.import
+++ b/examples/one_layer/player.ase.import
@@ -7,8 +7,10 @@ path="res://.godot/imported/player.ase-c01e0e86017cf506edc8169788aec93d.res"
 
 [deps]
 
+files=["res://examples/one_layer/textures/player_green_guy_spriteframes.tres", "res://examples/one_layer/textures/player_red_guy_spriteframes.tres"]
+
 source_file="res://examples/one_layer/player.ase"
-dest_files=["res://.godot/imported/player.ase-c01e0e86017cf506edc8169788aec93d.res"]
+dest_files=["res://.godot/imported/player.ase-c01e0e86017cf506edc8169788aec93d.res", "res://examples/one_layer/textures/player_green_guy_spriteframes.tres", "res://examples/one_layer/textures/player_red_guy_spriteframes.tres"]
 
 [params]
 

--- a/examples/stylebox/stylebox.ase.import
+++ b/examples/stylebox/stylebox.ase.import
@@ -7,8 +7,10 @@ path="res://.godot/imported/stylebox.ase-7660cf289f0c73e580a69f2876ba0d58.res"
 
 [deps]
 
+files=["res://examples/stylebox/textures/stylebox_style.tres", "res://examples/stylebox/textures/stylebox_style_stylebox.tres"]
+
 source_file="res://examples/stylebox/stylebox.ase"
-dest_files=["res://.godot/imported/stylebox.ase-7660cf289f0c73e580a69f2876ba0d58.res"]
+dest_files=["res://.godot/imported/stylebox.ase-7660cf289f0c73e580a69f2876ba0d58.res", "res://examples/stylebox/textures/stylebox_style.tres", "res://examples/stylebox/textures/stylebox_style_stylebox.tres"]
 
 [params]
 

--- a/examples/test_scene.tscn
+++ b/examples/test_scene.tscn
@@ -1,37 +1,154 @@
-[gd_scene format=3 uid="uid://y6a73h1ow8xw"]
+[gd_scene load_steps=19 format=4 uid="uid://y6a73h1ow8xw"]
 
-[ext_resource type="SpriteFrames" uid="uid://bcwg031ta8bfv" path="res://examples/full/textures/player_green_guy_base_spriteframes.tres" id="1_hldr7"]
-[ext_resource type="SpriteFrames" uid="uid://dmoigcyhxfmvx" path="res://examples/full/textures/player_green_guy_hat_spriteframes.tres" id="2_xdggk"]
 [ext_resource type="StyleBox" uid="uid://5sk86w2qqxeb" path="res://examples/stylebox/textures/stylebox_style_stylebox.tres" id="3_hldr7"]
-[ext_resource type="SpriteFrames" uid="uid://bim1kwsi64jtn" path="res://examples/full/textures/player_red_guy_base_spriteframes.tres" id="3_mwmxg"]
-[ext_resource type="SpriteFrames" uid="uid://djmo1s3ewhci3" path="res://examples/full/textures/player_red_guy_hat_spriteframes.tres" id="4_fkvod"]
 
-[node name="TestScene" type="Node2D" unique_id=1977151244]
+[sub_resource type="PortableCompressedTexture2D" id="PortableCompressedTexture2D_434x4"]
+_data = PackedByteArray("AAADAAUAAAABAAAAwAAAAAABAAA+BQAAUklGRjYFAABXRUJQVlA4TCoFAAAvv8A/ENfAIACAJHR3ww3+LwKdoDcYBABYZrYZ40qm0M9gBY0kNd/pVQXBC+5QigHmPwAA//9bW2gTffrBQ+eXhiUDKcKanXUIbmGsQVAQHKzz2r5LzFCINBbvcdQ+MaaMS0Is/LWF0EGWbdtRG1niBdwScIeS+Y8U9FqRm6+qRPQfkttGkiSrZ7sxa3IG/YbD/4oiHmI3WYLqJms43dy5FJYgB+kmbRoeoZtIhJvk8NwkV4pJDs5NWsUmh+peDHB0btIrNjgwN1mC717Qu0tB717guwt695Ot6xa87hX64o/91XUdWveryHWA3cU5wudetD3llWWFo3WXrnvKDIBurlQf/yZiVx+dm0zjJGzug+e5k9IBlttxaV4aG5m7WNPY0NxvM/wJ003F2QLC7YSP2+686tK/efM8rWy3W2Q/SiO3cvJw923cmnmVYpqlYtyzxG7jFk9+v89TtFv7mCf94P57U6nT2r1eA3e9z22pqon7k5kflpNPEZtSXbV4t+hMrEg3sU2CWTw5owe4k9C2aLc8gR/rvtSfBPNj1HO79TVws8S1cN+ls7fdfTKOYjbdhbVwp1YjdeNoHfncwhfPyHXvA+ZU53PAcl4P7nILcb3N7f+7FXY+X7Rdfcs5+3fJ28E9bsvMbiNdX966Km7PQxfO7fp+PFcjj1t/Wd2OXUVzZt20n527jN5y9XtzubWX0e08uwAUE//r+JfdH/V24jbiheRFvetXsKSkk3bgdry8C3jXap4q2oE7IG2i1D0yU2UQ7crtPIJKDeMaqaKH9uT2nkC9reFcxzH27HZS47lmzg7cf+hEPMRusgTVTdZwurlzKSxBDtJN2jQ8QjeRCDfJ4blJrhSTHJybtIpNDtW9GODo3KRXbHBgbrIE372gd5eC3r3Adxf07idb1y143Sv0xR/7q+s6tO5XkesAu4tzhM+9aHvKK8sKR+suXfeUGQDdXKk+/k3Erj46N5nGSdjcB89zJ6UDLLfj0rw0NjJ3saaxobnfZvgTppuKswWE2wkftx151aV/84ahX9lut8g+lUZu5eTh7tu4NfAqRT9IxbgHid3GLZ78eBz6aLf2MfT6wf33plKntWO9Bu56H9tSVRP3BzOfLCfvI9anumrxbtGZWJFuYusFs3hyRg9wJ6Ft0W55Aj/Wfak/CebTqOd262vgZolr4T5KZ2+7Y28cxaw/CmvhTq1G6sbROvK5hS+ekeveB8ypzueA5bwe3OUW4nqb2/93K+x8vmi7+pZz9u+St4N73JaZ3Ua6vrx1Vdyehy6c2/X9eK5GHrf+srodu4rmzLppPzt3Gb3l6vfmcmsvo9t5dgEoJv7X8S+7P+rtxG3EC8mLetevYElJJ+3A7Xh5F/Cu1TxVtAN3QNpEqXtkpsog2pXbeQSVGsY1UkUP7cntPYF6W8O5jmPs2e2kxnPNnB24/6mP1KC6yR5Gt+ycqkQ4QDfzqkl+dG4J7ZBjc9dqdG4/2xs2d6UG6G7J/kopQXenBMLdkI3enX4NdxUmt5f9rYwIqnvWmyo5QPfsCp57DgiTWyKjdtMcGOF139cejwcJHSC5hUszTZPj7QVj/3z3HttOA78///fX9EgNqpvsYXTLzr5KhAN0M6+a5EfnltAOOTZ3rUbn9rO9YXNXaoDuluyvlBJ0d0og3A3Z6N3p13BXYXJ72d/KiKC6B72+kgN0D67guYeAMLklMmo3DYERXvdx7XQ6kdABklu4NH3fO95eMPbPd++x7TTw+/N//2feAQ==")
+size_override = Vector2(192, 256)
 
-[node name="GreenGuy" type="AnimatedSprite2D" parent="." unique_id=593271239]
+[sub_resource type="AtlasTexture" id="AtlasTexture_iqljj"]
+atlas = SubResource("PortableCompressedTexture2D_434x4")
+region = Rect2(0, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_r0otj"]
+atlas = SubResource("PortableCompressedTexture2D_434x4")
+region = Rect2(64, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_c1c2t"]
+atlas = SubResource("PortableCompressedTexture2D_434x4")
+region = Rect2(128, 0, 64, 64)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_p854p"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_iqljj")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_r0otj")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_c1c2t")
+}],
+"loop": true,
+"name": &"walk-loop",
+"speed": 4.0
+}]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_5hm8q"]
+atlas = SubResource("PortableCompressedTexture2D_434x4")
+region = Rect2(0, 128, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_g3kdf"]
+atlas = SubResource("PortableCompressedTexture2D_434x4")
+region = Rect2(64, 128, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_mjlwq"]
+atlas = SubResource("PortableCompressedTexture2D_434x4")
+region = Rect2(128, 128, 64, 64)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_37ynw"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_5hm8q")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_g3kdf")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_mjlwq")
+}],
+"loop": true,
+"name": &"walk-loop",
+"speed": 4.0
+}]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_nu2q2"]
+atlas = SubResource("PortableCompressedTexture2D_434x4")
+region = Rect2(0, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_2netj"]
+atlas = SubResource("PortableCompressedTexture2D_434x4")
+region = Rect2(64, 64, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ynip6"]
+atlas = SubResource("PortableCompressedTexture2D_434x4")
+region = Rect2(128, 64, 64, 64)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_soiho"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_nu2q2")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_2netj")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ynip6")
+}],
+"loop": true,
+"name": &"walk-loop",
+"speed": 4.0
+}]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_fo2b1"]
+atlas = SubResource("PortableCompressedTexture2D_434x4")
+region = Rect2(0, 192, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_gstht"]
+atlas = SubResource("PortableCompressedTexture2D_434x4")
+region = Rect2(64, 192, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_8tade"]
+atlas = SubResource("PortableCompressedTexture2D_434x4")
+region = Rect2(128, 192, 64, 64)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_etaac"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_fo2b1")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_gstht")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_8tade")
+}],
+"loop": true,
+"name": &"walk-loop",
+"speed": 4.0
+}]
+
+[node name="TestScene" type="Node2D"]
+
+[node name="GreenGuy" type="AnimatedSprite2D" parent="."]
 position = Vector2(32, 32)
-sprite_frames = ExtResource("1_hldr7")
+sprite_frames = SubResource("SpriteFrames_p854p")
+animation = &"walk-loop"
+autoplay = "walk-loop"
+frame_progress = 0.651044
+
+[node name="GreenGuyHat" type="AnimatedSprite2D" parent="GreenGuy"]
+sprite_frames = SubResource("SpriteFrames_37ynw")
 animation = &"walk-loop"
 autoplay = "walk-loop"
 
-[node name="GreenGuyHat" type="AnimatedSprite2D" parent="GreenGuy" unique_id=1399600521]
-sprite_frames = ExtResource("2_xdggk")
-animation = &"walk-loop"
-autoplay = "walk-loop"
-
-[node name="RedGuy" type="AnimatedSprite2D" parent="." unique_id=1375067308]
+[node name="RedGuy" type="AnimatedSprite2D" parent="."]
 position = Vector2(99, 32)
-sprite_frames = ExtResource("3_mwmxg")
+sprite_frames = SubResource("SpriteFrames_soiho")
 animation = &"walk-loop"
 autoplay = "walk-loop"
 
-[node name="RedGuyHat" type="AnimatedSprite2D" parent="RedGuy" unique_id=1697748137]
+[node name="RedGuyHat" type="AnimatedSprite2D" parent="RedGuy"]
 visible = false
-sprite_frames = ExtResource("4_fkvod")
+sprite_frames = SubResource("SpriteFrames_etaac")
 animation = &"walk-loop"
 autoplay = "walk-loop"
 
-[node name="Panel" type="Panel" parent="." unique_id=1069724399]
+[node name="Panel" type="Panel" parent="."]
 offset_left = 147.0
 offset_top = 9.0
 offset_right = 182.0


### PR DESCRIPTION
Old resources will be deleted when unchecking a generate option.

The import pipeline collects all generated `AtlasTexture`/`StyleBoxTexture`/`SpriteFrames` resources into `gen_files`, reports them via `_gen_files`, and adds a `_prune_files` step that removes previously-generated outputs that are no longer produced (e.g., when a generate option is unchecked), deleting the `textures` folder if it becomes empty.